### PR TITLE
query response class migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 .ropeproject
 
 .idea
+config.ini

--- a/leexportpy/leexport.py
+++ b/leexportpy/leexport.py
@@ -24,7 +24,7 @@ LOG_FILE_PATH = '/var/log/leexportpy.log'
 PRINT_THREAD_INFO_INTERVAL_SECONDS = 100
 CONFIG_LOAD_INTERVAL_SECONDS = 300
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(threadName)s - %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.INFO
 
 
 def configure_options():

--- a/leexportpy/lerestresponse.py
+++ b/leexportpy/lerestresponse.py
@@ -3,6 +3,7 @@ import datetime
 DATEFORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
+# deprecated
 class LeRestResponse(object):
     """
     Helper class to wrap up response.

--- a/leexportpy/search.py
+++ b/leexportpy/search.py
@@ -4,7 +4,6 @@ import logging
 from twisted.internet import task
 
 from leexportpy import request_helper
-from leexportpy.lerestresponse import LeRestResponse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -13,7 +12,9 @@ class Search(object):
     """
     Class that handles search and push algorithms for exports.
     """
+
     def __init__(self, service_class, search_config, config):
+
         """
         Initialize this Search object with the related search_config.
 
@@ -31,7 +32,7 @@ class Search(object):
 
         :param resp: the final response object.
         """
-        response_metric = LeRestResponse(resp.json())
+        LOGGER.debug("Receieved final response: %s", resp.json())
         destination_config = self.search_config.get('destination')
         service_name = destination_config.get('service')
         service_api_key = self.config['Services'][service_name].get('api_key')
@@ -39,14 +40,13 @@ class Search(object):
         if self.service_class:
             LOGGER.info("A discovered service! "
                         "Service name: %s, class: %r", service_name, self.service_class)
-            service_object = self.service_class(response_metric, service_api_key,
+            service_object = self.service_class(resp.json(), service_api_key,
                                                 destination_config)
             service_object.process()
         else:
             LOGGER.error(
-                'Unknown transformation type: %s, '
-                'Are you sure the service class is appropriately placed in the "services" '
-                'directory?', service_name)
+                'Unknown transformation type: %s, Are you sure the service class is '
+                'appropriately placed in the "services" directory?', service_name)
             return
 
     def handle_response(self, response):
@@ -81,15 +81,15 @@ class Search(object):
         # after the first continuity response, if the query is still running on the server side,
         # server will return 200 with 'links' inside the json response for the following requests
         if response.status_code == 202:
-            continuity_response = request_helper.get_continuity_final_response(response,
-                                                                               self.config['LE'])
-            if continuity_response is None:
+            final_response = request_helper.get_continuity_final_response(response,
+                                                                          self.config['LE'])
+            if final_response is None:
                 # a non-200 continuity response after the first 202 will produce an Empty
                 # response and needs no more work
 
                 return
 
-            self.process_final_response(continuity_response)
+            self.process_final_response(final_response)
 
         if response.status_code == 200:
             # this is where we get into transforming & pushing business
@@ -102,14 +102,13 @@ class Search(object):
 
         :return:
         """
-        query_period = int(self.search_config['query'].get('query_period'))
-        LOGGER.debug("Query period for search (seconds): %i", query_period)
+        LOGGER.debug("Query period for search (seconds): %i", self.query_period)
 
         auth = self.config['LE']
 
         self.handle_response(request_helper.post_le_search(self.search_config.get('query'), auth))
         LOGGER.info("Waiting for the next cycle of query period. see you in %s seconds.",
-                    query_period)
+                    self.query_period)
 
     def start(self):
         """

--- a/leexportpy/service.py
+++ b/leexportpy/service.py
@@ -2,15 +2,15 @@ class Service(object):
     """
     Base class for service implementations in 'services' directory.
     """
-    def __init__(self, data, api_key, destination_config):
+    def __init__(self, response, api_key, destination_config):
         """
         Initialize service.
 
-        :param data:                data to be transformed
+        :param response:            data to be transformed
         :param api_key:             api key for 3rd party
         :param destination_config:  destination config of search
         """
-        self.data = data
+        self.response = response
         self.api_key = api_key
         self.destination_config = destination_config
 

--- a/leexportpy/services/dummy_service.py
+++ b/leexportpy/services/dummy_service.py
@@ -11,17 +11,17 @@ class DummyService(Service):
     """
     En example service class to show how to provide a new service support.
     """
-    def __init__(self, data, api_key, destination_config):
+    def __init__(self, response, api_key, destination_config):
         """
         Initialize DummyService
         """
-        super(DummyService, self).__init__(data, api_key, destination_config)
+        super(DummyService, self).__init__(response, api_key, destination_config)
 
     def transform(self):
         """
         Transform DummyService data.
         """
-        return {'payload': self.data}
+        return {'payload': self.response}
 
     def push(self, payload):
         """

--- a/leexportpy/services/geckoboard_service.py
+++ b/leexportpy/services/geckoboard_service.py
@@ -3,6 +3,8 @@ import logging
 
 import requests
 
+from leexportpy.queryresponse import QueryResponse, StatisticsResponse, \
+    TimeSeriesStatisticsResponse, GroupByStatisticsResponse
 from leexportpy.service import Service
 
 LOGGER = logging.getLogger(__name__)
@@ -13,15 +15,15 @@ class GeckoboardService(Service):
     Geckoboard Service class.
     """
 
-    def __init__(self, data, api_key, destination_config):
+    def __init__(self, response, api_key, destination_config):
         """
         Initialize Geckoboard service.
 
-        :param data:                data to be transformed
+        :param response:            data to be transformed
         :param api_key:             api key for 3rd party endpoint.
         :param destination_config:  destination config of search.
         """
-        super(GeckoboardService, self).__init__(data, api_key, destination_config)
+        super(GeckoboardService, self).__init__(response, api_key, destination_config)
 
     def process(self):
         """
@@ -62,49 +64,99 @@ class GeckoboardService(Service):
         """
         Convert query response to geckoboard line chart data.
         """
-        data = self.data.get_data()
-        x_axis = self.data.get_keys()
-        formatted_data = [{"name": self.destination_config.get('name'), "data": []}]
-        for index, item in enumerate(data):
-            key = item.keys()[0]
-            formatted_data[0]["data"].append([x_axis[index], item[key]])
+        if QueryResponse.is_statistics(self.response):
+            if StatisticsResponse.is_timeseries(self.response):
+                timeseries_response = TimeSeriesStatisticsResponse(self.response)
+                timeseries = timeseries_response.get_timeseries()
+                x_axis = timeseries_response.get_keys()
+                formatted_data = [{"name": self.destination_config.get('name'), "data": []}]
+                for index, item in enumerate(timeseries):
+                    key = item.keys()[0]
+                    formatted_data[0]["data"].append([x_axis[index], item[key]])
 
-        line_chart_json = {"data": {"x_axis": {"type": "datetime"}, "series": []}}
-        line_chart_json["data"]["series"] = formatted_data
-        return line_chart_json
+                line_chart_json = {"data": {"x_axis": {"type": "datetime"}, "series": []}}
+                line_chart_json["data"]["series"] = formatted_data
+                return line_chart_json
+            else:
+                LOGGER.warn(
+                    'Response does not contain timeseries result. Geckoboard line chart needs '
+                    'timeseries result.')
+        else:
+            LOGGER.warn('Response does not contain statistics result, geckoboard pie chart needs '
+                        'statistics.')
+            return None
 
     def format_pie_chart_data(self):
         """
         Convert query response to geckoboard pie chart data.
         """
-        data = self.data.get_data()
-        formatted_data = []
-        LOGGER.debug('Size of group array: %i', len(data))
+        if QueryResponse.is_statistics(self.response):
+            if StatisticsResponse.is_groupby(self.response):
+                groupby_response = GroupByStatisticsResponse(self.response)
 
-        for item in data:
-            label = str(item.keys()[0])
-            value = item[label]['count']
-            LOGGER.debug('key/value is: %s, %i', label, value)
-            formatted_data.append({"label": label, "value": value})
+                formatted_data = []
+                LOGGER.debug('Size of group array: %i', len(groupby_response.get_groups()))
 
-        pie_chart_data = {"data": {"item": []}}
-        pie_chart_data["data"]["item"] = formatted_data
-        return pie_chart_data
+                for item in groupby_response.get_groups():
+                    label = str(item.keys()[0])
+                    value = item[label]['count']
+                    LOGGER.debug('key/value is: %s, %i', label, value)
+                    formatted_data.append({"label": label, "value": value})
+
+                pie_chart_data = {"data": {"item": []}}
+                pie_chart_data["data"]["item"] = formatted_data
+                return pie_chart_data
+            else:
+                LOGGER.warn('Response does not contain groupby result. Geckoboard pie chart '
+                            'needs groupby result.')
+                return None
+        else:
+            LOGGER.warn('Response does not contain statistics result, geckoboard pie chart needs '
+                        'statistics.')
+            return None
 
     def format_bar_chart_data(self):
         """
         Convert query response to bar chart data.
         """
-        keys = self.data.get_keys()
-        values = self.data.get_values()
-        return {'data': {'x_axis': {'labels': keys, 'type': 'datetime'},
-                         'y_axis': {'format': 'decimal'},
-                         'series': [{'data': values}]}}
+        if QueryResponse.is_statistics(self.response):
+            if StatisticsResponse.is_timeseries(self.response):
+                response_object = TimeSeriesStatisticsResponse(self.response)
+            elif StatisticsResponse.is_groupby(self.response):
+                response_object = GroupByStatisticsResponse(self.response)
+            else:
+                LOGGER.warn('Response contains neither timeseries nor groupby result. Geckoboard '
+                            'bar chart needs either of them.')
+                return None
+
+            keys = response_object.get_keys()
+            values = response_object.get_values()
+            return {'data': {'x_axis': {'labels': keys, 'type': 'datetime'},
+                             'y_axis': {'format': 'decimal'},
+                             'series': [{'data': values}]}}
+        else:
+            LOGGER.warn('Response does not contain statistics result, geckoboard bar chart needs '
+                        'statistics.')
+            return None
 
     def format_number_stat_data(self):
         """
         Convert query response to number stat data.
         """
-        count = self.data.get_statistics_count()
-        LOGGER.debug("Number stat data count: %i", count)
-        return {"data": {"item": [{"value": count, "text": self.destination_config.get('text')}]}}
+        if QueryResponse.is_statistics(self.response):
+            if StatisticsResponse.is_timeseries(self.response):
+                timeseries_response = TimeSeriesStatisticsResponse(self.response)
+
+                count = timeseries_response.get_count()
+                LOGGER.debug("Number stat data count: %i", count)
+                return {"data": {
+                    "item": [{"value": count, "text": self.destination_config.get('text')}]}}
+            else:
+                LOGGER.warn(
+                    'Response does not contain timeseries result. Geckoboard number stat widget '
+                    'needs timeseries result.')
+            return None
+        else:
+            LOGGER.warn('Response does not contain statistics result, geckoboard number stat '
+                        'widget needs statistics.')
+            return None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='leexportpy',
-    version='0.1.5',
+    version='0.1.7',
     author='Safa Topal',
     author_email='Safa_Topal@rapid7.com',
     packages=find_packages(exclude=['*tests*']),

--- a/tests/test_geckoboard_service.py
+++ b/tests/test_geckoboard_service.py
@@ -4,13 +4,13 @@ from mock import patch
 from tests.examples import config_examples as conf_ex
 from tests.examples import request_examples as req_ex
 from tests.examples import response_examples as resp_ex
-from leexportpy.lerestresponse import LeRestResponse
 from leexportpy.services.geckoboard_service import GeckoboardService
 
 
 def test_number_stat_process_calls_push():
     with patch.object(GeckoboardService, 'push') as mocked_number_stat_push:
-        gecko_job_number_stat = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY,
+        gecko_job_number_stat = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                                  req_ex.SERVICE_API_KEY,
                                                   conf_ex.GECKO_NUMBER_STAT_CONFIG)
         gecko_job_number_stat.process()
         assert mocked_number_stat_push.called
@@ -18,21 +18,27 @@ def test_number_stat_process_calls_push():
 
 def test_line_chart_process_calls_push():
     with patch.object(GeckoboardService, 'push') as mocked_line_chart_push:
-        gecko_job_line_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_LINE_CHART_CONFIG)
+        gecko_job_line_chart = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                                 req_ex.SERVICE_API_KEY,
+                                                 conf_ex.GECKO_LINE_CHART_CONFIG)
         gecko_job_line_chart.process()
         assert mocked_line_chart_push.called
 
 
 def test_pie_chart_process_calls_push():
     with patch.object(GeckoboardService, 'push') as mocked_pie_chart_push:
-        gecko_job_pie_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_PIE_CHART_CONFIG)
+        gecko_job_pie_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                                req_ex.SERVICE_API_KEY,
+                                                conf_ex.GECKO_PIE_CHART_CONFIG)
         gecko_job_pie_chart.process()
         assert mocked_pie_chart_push.called
 
 
 def test_bar_chart_process_calls_push():
     with patch.object(GeckoboardService, 'push') as mocked_bar_chart_push:
-        gecko_job_bar_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_BAR_CHART_CONFIG)
+        gecko_job_bar_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                                req_ex.SERVICE_API_KEY,
+                                                conf_ex.GECKO_BAR_CHART_CONFIG)
         gecko_job_bar_chart.process()
         assert mocked_bar_chart_push.called
 
@@ -41,7 +47,9 @@ def test_bar_chart_process_calls_push():
 def test__number_stat_push():
     httpretty.register_uri(httpretty.POST, req_ex.DEST_URL,
                            body="OK")
-    gecko_job_number_stat = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_NUMBER_STAT_CONFIG)
+    gecko_job_number_stat = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                              req_ex.SERVICE_API_KEY,
+                                              conf_ex.GECKO_NUMBER_STAT_CONFIG)
     gecko_job_number_stat.push({})
 
     assert httpretty.has_request()
@@ -51,7 +59,9 @@ def test__number_stat_push():
 def test_line_chart_push():
     httpretty.register_uri(httpretty.POST, req_ex.DEST_URL,
                            body="OK")
-    gecko_job_line_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_LINE_CHART_CONFIG)
+    gecko_job_line_chart = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                             req_ex.SERVICE_API_KEY,
+                                             conf_ex.GECKO_LINE_CHART_CONFIG)
     gecko_job_line_chart.push({})
 
     assert httpretty.has_request()
@@ -61,7 +71,9 @@ def test_line_chart_push():
 def test_pie_chart_push():
     httpretty.register_uri(httpretty.POST, req_ex.DEST_URL,
                            body="OK")
-    gecko_job_pie_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_PIE_CHART_CONFIG)
+    gecko_job_pie_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                            req_ex.SERVICE_API_KEY,
+                                            conf_ex.GECKO_PIE_CHART_CONFIG)
     gecko_job_pie_chart.push({})
 
     assert httpretty.has_request()
@@ -71,14 +83,18 @@ def test_pie_chart_push():
 def test_bar_chart_push():
     httpretty.register_uri(httpretty.POST, req_ex.DEST_URL,
                            body="OK")
-    gecko_job_bar_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_BAR_CHART_CONFIG)
+    gecko_job_bar_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                            req_ex.SERVICE_API_KEY,
+                                            conf_ex.GECKO_BAR_CHART_CONFIG)
     gecko_job_bar_chart.push({})
 
     assert httpretty.has_request()
 
 
 def test_format_number_stat_data():
-    gecko_job_number_stat = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_NUMBER_STAT_CONFIG)
+    gecko_job_number_stat = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                              req_ex.SERVICE_API_KEY,
+                                              conf_ex.GECKO_NUMBER_STAT_CONFIG)
     number_stat = gecko_job_number_stat.format_number_stat_data()
 
     assert "data" in number_stat
@@ -89,13 +105,15 @@ def test_format_number_stat_data():
 
     the_item = item[0]
     assert "value" in the_item
-    assert the_item["value"] == 1234
+    assert the_item["value"] == 27733.0
     assert "text" in the_item
     assert the_item["text"] == "number_stat_text"
 
 
 def test_format_bar_chart_data():
-    gecko_job_bar_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_BAR_CHART_CONFIG)
+    gecko_job_bar_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                            req_ex.SERVICE_API_KEY,
+                                            conf_ex.GECKO_BAR_CHART_CONFIG)
     bar_chart_json = gecko_job_bar_chart.format_bar_chart_data()
 
     assert "data" in bar_chart_json
@@ -106,7 +124,9 @@ def test_format_bar_chart_data():
 
 
 def test_format_pie_chart_data():
-    gecko_job_pie_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_PIE_CHART_CONFIG)
+    gecko_job_pie_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                            req_ex.SERVICE_API_KEY,
+                                            conf_ex.GECKO_PIE_CHART_CONFIG)
     pie_data = gecko_job_pie_chart.format_pie_chart_data()
 
     assert "data" in pie_data
@@ -117,7 +137,9 @@ def test_format_pie_chart_data():
 
 
 def test_format_line_chart_data():
-    gecko_job_line_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_LINE_CHART_CONFIG)
+    gecko_job_line_chart = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                             req_ex.SERVICE_API_KEY,
+                                             conf_ex.GECKO_LINE_CHART_CONFIG)
     line_chart_data = gecko_job_line_chart.format_line_chart_data()
 
     assert "data" in line_chart_data
@@ -126,21 +148,26 @@ def test_format_line_chart_data():
 
 def test_line_chart_transform():
     with patch.object(GeckoboardService, 'transform', return_value=None) as mock_transform:
-        gecko_job_line_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_LINE_CHART_CONFIG)
+        gecko_job_line_chart = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                                 req_ex.SERVICE_API_KEY,
+                                                 conf_ex.GECKO_LINE_CHART_CONFIG)
         gecko_job_line_chart.transform()
         assert mock_transform.called
 
 
 def test_pie_chart_transform():
     with patch.object(GeckoboardService, 'transform', return_value=None) as mock_transform:
-        gecko_job_pie_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_PIE_CHART_CONFIG)
+        gecko_job_pie_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                                req_ex.SERVICE_API_KEY,
+                                                conf_ex.GECKO_PIE_CHART_CONFIG)
         gecko_job_pie_chart.transform()
         assert mock_transform.called
 
 
 def test_number_stat_transform():
     with patch.object(GeckoboardService, 'transform', return_value=None) as mock_transform:
-        gecko_job_number_stat = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY,
+        gecko_job_number_stat = GeckoboardService(resp_ex.FULL_TIMESERIES_RESP,
+                                                  req_ex.SERVICE_API_KEY,
                                                   conf_ex.GECKO_NUMBER_STAT_CONFIG)
         gecko_job_number_stat.transform()
         assert mock_transform.called
@@ -148,6 +175,8 @@ def test_number_stat_transform():
 
 def test_bar_chart_transform():
     with patch.object(GeckoboardService, 'transform', return_value=None) as mock_transform:
-        gecko_job_bar_chart = GeckoboardService(LeRestResponse(resp_ex.FULL_GROUP_RESP), req_ex.SERVICE_API_KEY, conf_ex.GECKO_BAR_CHART_CONFIG)
+        gecko_job_bar_chart = GeckoboardService(resp_ex.FULL_GROUP_RESP,
+                                                req_ex.SERVICE_API_KEY,
+                                                conf_ex.GECKO_BAR_CHART_CONFIG)
         gecko_job_bar_chart.transform()
         assert mock_transform.called

--- a/tests/test_hosted_graphite_service.py
+++ b/tests/test_hosted_graphite_service.py
@@ -6,14 +6,12 @@ from mock import patch
 from tests.examples import config_examples as conf_ex
 from tests.examples import request_examples as req_ex
 from tests.examples import response_examples as resp_ex
-from leexportpy.lerestresponse import LeRestResponse
 from leexportpy.services.hosted_graphite_service import HostedGraphiteService
 
 
 def test_convert_to_hostedgraphite_data():
-    full_ts_resp_object = LeRestResponse(
-        {"logs": resp_ex.LOGS, "statistics": resp_ex.TIMESERIES_STATISTICS, "leql": resp_ex.LEQL})
-    hosted_graphite_job = HostedGraphiteService(full_ts_resp_object, req_ex.SERVICE_API_KEY,
+    hosted_graphite_job = HostedGraphiteService(resp_ex.FULL_TIMESERIES_RESP,
+                                                req_ex.SERVICE_API_KEY,
                                                 conf_ex.SEARCH_HOSTED_GRAPHITE)
 
     hg_data = hosted_graphite_job.transform()
@@ -24,7 +22,8 @@ def test_convert_to_hostedgraphite_data():
 
 def test_process():
     with patch.object(HostedGraphiteService, 'push', return_value=None) as mock_push:
-        hosted_graphite_job = HostedGraphiteService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY,
+        hosted_graphite_job = HostedGraphiteService(resp_ex.FULL_TIMESERIES_RESP,
+                                                    req_ex.SERVICE_API_KEY,
                                                     conf_ex.SEARCH_HOSTED_GRAPHITE)
 
         hosted_graphite_job.process()
@@ -34,7 +33,8 @@ def test_process():
 
 @httpretty.activate
 def test_push():
-    hosted_graphite_job = HostedGraphiteService(LeRestResponse(resp_ex.FULL_TIMESERIES_RESP), req_ex.SERVICE_API_KEY,
+    hosted_graphite_job = HostedGraphiteService(resp_ex.FULL_TIMESERIES_RESP,
+                                                req_ex.SERVICE_API_KEY,
                                                 conf_ex.SEARCH_HOSTED_GRAPHITE)
     httpretty.register_uri(httpretty.PUT, req_ex.DEST_URL,
                            body="OK")


### PR DESCRIPTION
I have started working on this query_response classes for different kind of responses we get from Logentries REST API like: Events or Statistics. And statistics currently can have two forms: groupby and timeseries. I have now completed it and migrated the rest of the code to this module.

We can now deprecate lerestresponse.py - and can remove it in the following release. 
